### PR TITLE
Make recipe search case-insensitive

### DIFF
--- a/The Keto Bible/DataManager.swift
+++ b/The Keto Bible/DataManager.swift
@@ -348,9 +348,9 @@ class DataManager: NSObject {
     func searchRecipes(searchTerm : String, searchBar : UISearchBar!, completion: (([RecipeItem]?) -> Void)?) {
         
         var results = [RecipeItem]()
-        if recipes  != nil {
-            for recipe in recipes! {
-                if recipe.title.contains(searchTerm) {
+        if let recipes = recipes {
+            for recipe in recipes {
+                if recipe.title.range(of: searchTerm, options: .caseInsensitive) != nil {
                     results.append(recipe)
                 }
             }


### PR DESCRIPTION
## Summary
- allow recipe title matching in searches regardless of letter case

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689ab38bae0883249ad690cc0a07a4eb